### PR TITLE
Don't Translate Objectives/Constraints in Xopt Loader

### DIFF
--- a/notebooks/xopt_cnsga_importer.ipynb
+++ b/notebooks/xopt_cnsga_importer.ipynb
@@ -112,12 +112,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# If the data already is saved to disk with an Xopt config file the VOCS object may be loaded like this\n",
+    "# import yaml\n",
+    "# from xopt import VOCS\n",
+    "# with open(\"config.yml\") as f:\n",
+    "#     dat = yaml.safe_load(f)\n",
+    "# vocs = VOCS(**dat['vocs'])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "electronsandstuff",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -131,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/src/electronsandstuff/paretobench/xopt.py
+++ b/src/electronsandstuff/paretobench/xopt.py
@@ -119,8 +119,8 @@ def import_cnsga_population(
     # Get base constraints if they exist
     g = df[vocs.constraint_names].to_numpy() if vocs.constraints else None
     names_g = vocs.constraint_names
-    boundary_g = [vocs.constraints[name][1] for name in vocs.constraint_names]
-    less_than_g = [vocs.constraints[name][0] == "LESS_THAN" for name in vocs.constraint_names]
+    constraint_targets = [vocs.constraints[name][1] for name in vocs.constraint_names]
+    constraint_directions = [vocs.constraints[name][0] == "GREATER_THAN" for name in vocs.constraint_names]
 
     # Handle error column if requested
     if errors_as_constraints:
@@ -135,8 +135,8 @@ def import_cnsga_population(
         else:
             g = error_constraints
         names_g.append("xopt_error")
-        boundary_g.append(0.0)
-        less_than_g.append(False)
+        constraint_targets.append(0.0)
+        constraint_directions.append(True)
 
     return Population(
         x=df[vocs.variable_names].to_numpy(),
@@ -145,9 +145,9 @@ def import_cnsga_population(
         names_x=vocs.variable_names,
         names_f=vocs.objective_names,
         names_g=names_g,
-        maximize_f=np.array([vocs.objectives[name] == "MAXIMIZE" for name in vocs.objective_names]),
-        less_than_g=np.array(less_than_g),
-        boundary_g=np.array(boundary_g),
+        obj_directions=np.array([vocs.objectives[name] == "MAXIMIZE" for name in vocs.objective_names]),
+        constraint_directions=np.array(constraint_directions),
+        constraint_targets=np.array(constraint_targets),
     )
 
 

--- a/src/electronsandstuff/paretobench/xopt.py
+++ b/src/electronsandstuff/paretobench/xopt.py
@@ -117,8 +117,10 @@ def import_cnsga_population(
     df = pd.read_csv(path)
 
     # Get base constraints if they exist
-    g = -vocs.constraint_data(df).to_numpy() if vocs.constraints else None
+    g = df[vocs.constraint_names].to_numpy() if vocs.constraints else None
     names_g = vocs.constraint_names
+    boundary_g = [vocs.constraints[name][1] for name in vocs.constraint_names]
+    less_than_g = [vocs.constraints[name][0] == "LESS_THAN" for name in vocs.constraint_names]
 
     # Handle error column if requested
     if errors_as_constraints:
@@ -133,14 +135,19 @@ def import_cnsga_population(
         else:
             g = error_constraints
         names_g.append("xopt_error")
+        boundary_g.append(0.0)
+        less_than_g.append(False)
 
     return Population(
-        x=vocs.variable_data(df).to_numpy(),
-        f=vocs.objective_data(df).to_numpy(),
+        x=df[vocs.variable_names].to_numpy(),
+        f=df[vocs.objective_names].to_numpy(),
         g=g,
         names_x=vocs.variable_names,
         names_f=vocs.objective_names,
         names_g=names_g,
+        maximize_f=np.array([vocs.objectives[name] == "MAXIMIZE" for name in vocs.objective_names]),
+        less_than_g=np.array(less_than_g),
+        boundary_g=np.array(boundary_g),
     )
 
 

--- a/src/electronsandstuff/paretobench/xopt.py
+++ b/src/electronsandstuff/paretobench/xopt.py
@@ -120,7 +120,7 @@ def import_cnsga_population(
     g = df[vocs.constraint_names].to_numpy() if vocs.constraints else None
     names_g = vocs.constraint_names
     constraint_targets = [vocs.constraints[name][1] for name in vocs.constraint_names]
-    constraint_directions = [vocs.constraints[name][0] == "GREATER_THAN" for name in vocs.constraint_names]
+    constraint_directions = [">" if vocs.constraints[name][0] == "GREATER_THAN" else "<" for name in vocs.constraint_names]
 
     # Handle error column if requested
     if errors_as_constraints:
@@ -136,7 +136,7 @@ def import_cnsga_population(
             g = error_constraints
         names_g.append("xopt_error")
         constraint_targets.append(0.0)
-        constraint_directions.append(True)
+        constraint_directions.append(">")
 
     return Population(
         x=df[vocs.variable_names].to_numpy(),
@@ -145,8 +145,8 @@ def import_cnsga_population(
         names_x=vocs.variable_names,
         names_f=vocs.objective_names,
         names_g=names_g,
-        obj_directions=np.array([vocs.objectives[name] == "MAXIMIZE" for name in vocs.objective_names]),
-        constraint_directions=np.array(constraint_directions),
+        obj_directions="".join(["+" if vocs.objectives[name] == "MAXIMIZE" else "-" for name in vocs.objective_names]),
+        constraint_directions="".join(constraint_directions),
         constraint_targets=np.array(constraint_targets),
     )
 


### PR DESCRIPTION
This PR updates the Xopt loader for ParetoBench with recent changes to the library that allow for problems other than minimization with constraints such that g >= 0. This means we can avoid transforming data upon import into the history object.

- Constraint and objective settings are loaded in using the new ParetoBench Population object interface
- The code was tested on an external example with non-standard objectives/constraints
- The notebook was updated with example code to load Xopt VOCs object from YAML file